### PR TITLE
Wdl indent level

### DIFF
--- a/wdl-mode.el
+++ b/wdl-mode.el
@@ -21,6 +21,9 @@
 ;; Syntax table and font-lock types
 (defvar wdl-mode-syntax-table nil "Syntax table for `wdl-mode'.")
 
+(defvar wdl-indent-level 2
+  "Indentation of statements with respect to containing block.")
+
 (setq wdl-mode-syntax-table
       (let ( (synTable (make-syntax-table)))
         ;; python style comment: “# …”
@@ -85,7 +88,7 @@
           (progn
             (save-excursion
               (forward-line -1)
-              (setq cur-indent (- (current-indentation) tab-width)))
+              (setq cur-indent (- (current-indentation) wdl-indent-level)))
             (if (< cur-indent 0) ; We can't indent past the left margin
                 (setq cur-indent 0)))
         (save-excursion
@@ -97,7 +100,7 @@
                   (setq not-indented nil))
               (if (looking-at "^.*\\(<<<\\|{\\)$") ; This hint indicates that we need to indent an extra level
                   (progn
-                    (setq cur-indent (+ (current-indentation) tab-width)) ; Do the actual indenting
+                    (setq cur-indent (+ (current-indentation) wdl-indent-level)) ; Do the actual indenting
                     (setq not-indented nil))
                 (if (bobp)
                     (setq not-indented nil)))))))

--- a/wdl-mode.el
+++ b/wdl-mode.el
@@ -14,6 +14,25 @@
 
 ;; This package provides a major mode for WDL (Workflow Definition Language).
 ;; It supports basic font-lock highlights and indentation.
+;;
+;; Installation instructions:
+;;
+;;   $ cd YOUR_GIT_DIRECTORY
+;;   $ git clone https://github.com/plijnzaad/wdl-mode.git
+;;
+;; and add EITHER the following line to your .emacs file
+;;     (require 'wdl-mode "YOUR_GIT_DIRECTORY/wdl-mode/wdl-mode.el" t)
+;;
+;; to always load the mode, OR make it autoload by adding the following:
+;;
+;;     (add-to-list 'auto-mode-alist '("\\.wdl\\'" . wdl-mode))
+;;     (autoload 'wdl-mode YOUR_GIT_DIRECTORY/wdl-mode/wdl-mode.el" nil t)
+;;
+;; and execute it (or restart emacs). To adjust the indentation setting
+;; add something like this to your .emacs: 
+;;
+;;     (setq wdl-indent-level 4)
+;;
 
 ;;; Code:
 


### PR DESCRIPTION
Hi,

this pull request uses the variable wdl-indent-level, which ought to make it easier to customize (although I'm not using the `customize` mechanism). 

I also included some quick installation instructions in the comments at the top of the `wdl-mode.el`